### PR TITLE
`next` does not work on lists

### DIFF
--- a/traduki/helpers.py
+++ b/traduki/helpers.py
@@ -78,7 +78,6 @@ def get_text_from_dict(mydict, code=None, chain=None):
         if chain and '*' in chain:
             # found 'everything' chain element
             code = chain['*']
-        return next(_dict.values(), u'')
     try:
         code_base, code_variant = check_language_code(code)
     except (TypeError, KeyError):


### PR DESCRIPTION
`next` does not work on lists, such as what is returned from `_dict.values()`. Further, instead of returning early, just let the function continue with `code` now set.
