### PR TITLE
 Use an OR operator for LIKE_OPS to find matches in all language columns 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,13 @@
 Changelog
 =========
 
+1.1.0
+-----
+
+* Use an OR operator for LIKE_OPS to find matches in all language columns.
+
 1.0.1
-----------
+-----
 
 * Fix `get_text_from_dict` raising an exception when no language can be detected.
 

--- a/README.rst
+++ b/README.rst
@@ -74,4 +74,4 @@ This software is licensed under the `MIT license <http://en.wikipedia.org/wiki/M
 See `License <https://github.com/paylogic/traduki/blob/master/LICENSE.txt>`_
 
 
-© 2013 Paylogic International.
+© 2018 Paylogic International.

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 from os.path import abspath, dirname, join
 
 from setuptools import setup, find_packages
-import sys
 
 long_description = []
 
@@ -13,7 +12,7 @@ setup(
     name='traduki',
     description='SQLAlchemy internationalisation',
     long_description='\n'.join(long_description),
-    version='1.0.1',
+    version='1.1.0',
     author='Paylogic International',
     author_email='developers@paylogic.com',
     license='MIT',

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -16,7 +16,7 @@ Base = declarative_base()
 @pytest.fixture(scope='session')
 def languages():
     """Supported languages."""
-    return ['en', 'pt']
+    return ['en', 'nl', 'pt']
 
 
 @pytest.fixture(scope='session')
@@ -68,7 +68,7 @@ def engine(request, model_class):
 @pytest.fixture
 def model_title():
     """Model title."""
-    return {'en': 'En Title', 'pt': 'Pt Title'}
+    return {'en': 'En Title', 'nl': 'Nl Title', 'pt': 'Pt Title'}
 
 
 @pytest.fixture
@@ -110,9 +110,15 @@ def test_set(model):
     assert model.title.get_dict() == {'en': 'New'}
 
 
-def test_comparator(session, model, model_class):
-    """Test field comparator."""
+def test_startswith(session, model, model_class):
+    """Test startswith comparator."""
     assert model in session.query(model_class).filter(model_class.title.startswith('En Title'))
     assert model in session.query(model_class).filter(model_class.title.startswith('Pt Title'))
+    assert model not in session.query(model_class).filter(model_class.title.startswith('Fr Title'))
+
+
+def test_contains(session, model, model_class):
+    """Test contains comparator."""
     assert model in session.query(model_class).filter(model_class.title.contains('En'))
     assert model in session.query(model_class).filter(model_class.title.contains('Pt'))
+    assert model not in session.query(model_class).filter(model_class.title.contains('Fr'))

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -113,4 +113,6 @@ def test_set(model):
 def test_comparator(session, model, model_class):
     """Test field comparator."""
     assert model in session.query(model_class).filter(model_class.title.startswith('En Title'))
-    assert model not in session.query(model_class).filter(model_class.title.startswith('Pt Title'))
+    assert model in session.query(model_class).filter(model_class.title.startswith('Pt Title'))
+    assert model in session.query(model_class).filter(model_class.title.contains('En'))
+    assert model in session.query(model_class).filter(model_class.title.contains('Pt'))

--- a/traduki/sqla.py
+++ b/traduki/sqla.py
@@ -109,7 +109,7 @@ def initialize(base, languages, get_current_language_callback, get_language_chai
             return self.operate(oper.contains_op, other, escape=escape)
 
         def _do_compare(self, op, other, escape):
-            """Perform comparison operations to the columns of Translation model.
+            """Perform comparison operations to the columns of the Translation model.
             Looking into all languages using the OR operator.
             """
             related = self.property.mapper.class_

--- a/traduki/sqla.py
+++ b/traduki/sqla.py
@@ -95,9 +95,7 @@ def initialize(base, languages, get_current_language_callback, get_language_chai
         All the `like` operations will look into next language if the specified language is not filled in.
         """
 
-        LIKE_OPS = set([
-            oper.like_op, oper.contains_op, oper.startswith_op,
-            oper.endswith_op])
+        LIKE_OPS = {oper.like_op, oper.contains_op, oper.startswith_op, oper.endswith_op}
 
         # Only the operators in LIKE_OPS are allowed on this relationship
         def operate(self, op, *other, **kw):
@@ -111,7 +109,7 @@ def initialize(base, languages, get_current_language_callback, get_language_chai
             return self.operate(oper.contains_op, other, escape=escape)
 
         def _do_compare(self, op, other, escape):
-            """Perform coalesced comparison operations to the columns of Translation model.
+            """Perform comparison operations to the columns of Translation model.
             Looking into all languages using the OR operator.
             """
             related = self.property.mapper.class_

--- a/traduki/sqla.py
+++ b/traduki/sqla.py
@@ -13,7 +13,7 @@ from sqlalchemy.exc import ArgumentError
 from sqlalchemy.orm import relationship
 from sqlalchemy.orm.interfaces import AttributeExtension
 from sqlalchemy.orm.properties import RelationshipProperty
-from sqlalchemy.sql import operators as oper, functions as func
+from sqlalchemy.sql import operators as oper, or_
 
 from traduki import config
 from traduki import helpers
@@ -120,7 +120,7 @@ def initialize(base, languages, get_current_language_callback, get_language_chai
                 for lang in helpers.get_ordered_languages()
                 if hasattr(related, lang)
             ]
-            return self.has(oper.or_(*ops))
+            return self.has(or_(*ops))
 
     class TranslationExtension(AttributeExtension):
         """AttributeExtension to override the behavior of .set, to accept a dict as new value."""

--- a/traduki/sqla.py
+++ b/traduki/sqla.py
@@ -112,11 +112,15 @@ def initialize(base, languages, get_current_language_callback, get_language_chai
 
         def _do_compare(self, op, other, escape):
             """Perform coalesced comparison operations to the columns of Translation model.
-            Looking into the the next language if the given language is not filled in.
+            Looking into all languages using the OR operator.
             """
             related = self.property.mapper.class_
-            cols = [getattr(related, lang) for lang in helpers.get_ordered_languages() if hasattr(related, lang)]
-            return self.has(op(func.coalesce(*cols), other, escape=escape))
+            ops = [
+                op(getattr(related, lang), other, escape=escape)
+                for lang in helpers.get_ordered_languages()
+                if hasattr(related, lang)
+            ]
+            return self.has(oper.or_(*ops))
 
     class TranslationExtension(AttributeExtension):
         """AttributeExtension to override the behavior of .set, to accept a dict as new value."""


### PR DESCRIPTION
**Current behavior for `LIKE_OPS` (like, contains, startswith)**

Look only in the first language column that is populated by using a `coalesce` operator.

**New behavior**

Look in all language columns by using an `or_` operator.