### PR TITLE
Fix sqlalchemy2 warning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+1.3.3
+-----
+* Fix sqlalchemy 2.0 compatibility warning by using `sqlalchemy.orm.Mapper` instead of `sqlalchemy.orm.mapper`.
+
 1.3.2
 -----
 * Fix a bug where the `get_ordered_languages` would mutate in place the list of configured languages.

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     name='traduki',
     description='SQLAlchemy internationalisation',
     long_description=u'\n'.join(long_description),
-    version='1.3.2',
+    version='1.3.3',
     author='Paylogic International',
     author_email='developers@paylogic.com',
     license='MIT',

--- a/traduki/sqla.py
+++ b/traduki/sqla.py
@@ -11,7 +11,7 @@ import collections
 import six
 from sqlalchemy import Column, Integer, ForeignKey, UnicodeText, event
 from sqlalchemy.exc import ArgumentError
-from sqlalchemy.orm import relationship, mapper
+from sqlalchemy.orm import relationship, Mapper
 from sqlalchemy.orm.base import NO_VALUE, NEVER_SET
 from sqlalchemy.orm.properties import RelationshipProperty
 from sqlalchemy.sql import operators as oper, or_
@@ -191,7 +191,7 @@ def initialize(base, languages, get_current_language_callback, get_language_chai
 
         # We must attach the event on before_configured. If we use after_configured, we're too late
         # as other hooks will already be installed by SQLAlchemy.
-        @event.listens_for(mapper, 'before_configured')
+        @event.listens_for(Mapper, 'before_configured')
         def setup_translation_set():
             event.listen(
                 res,


### PR DESCRIPTION
Simple fix for this warning in sqlalchemy 2.0

`env/lib/python3.9/site-packages/traduki/sqla.py:195: SADeprecationWarning: The `sqlalchemy.orm.mapper()` symbol is deprecated and will be removed in a future release. For the mapper-wide event target, use the 'sqlalchemy.orm.Mapper' class.
    def setup_translation_set():`